### PR TITLE
Support for selecting one item from a list of items

### DIFF
--- a/KSPManager.cs
+++ b/KSPManager.cs
@@ -34,9 +34,9 @@ namespace CKAN
             }
         }
 
-        public Dictionary<string, KSP> Instances
+        public SortedList<string, KSP> Instances
         {
-            get { return new Dictionary<string, KSP>(instances); }            
+            get { return new SortedList<string, KSP>(instances); }            
         }
 
 

--- a/KSPManager.cs
+++ b/KSPManager.cs
@@ -19,7 +19,7 @@ namespace CKAN
 
         private static readonly ILog log = LogManager.GetLogger(typeof (KSPManager));
 
-        private readonly Dictionary<string, KSP> instances = new Dictionary<string, KSP>();
+        private readonly SortedList<string, KSP> instances = new SortedList<string, KSP>();
 
         internal string AutoStartInstance
         {

--- a/Tests/CKAN/KSPManager.cs
+++ b/Tests/CKAN/KSPManager.cs
@@ -195,7 +195,7 @@ namespace CKANTests
             return Instances[i];
         }
 
-        public void SetRegistryToInstances(Dictionary<string, CKAN.KSP> instances, string auto_start_instance)
+        public void SetRegistryToInstances(SortedList<string, CKAN.KSP> instances, string auto_start_instance)
         {
             Instances =
                 instances.Select((kvpair) => new Tuple<string, string>(kvpair.Key, kvpair.Value.GameDir())).ToList();

--- a/User.cs
+++ b/User.cs
@@ -1,12 +1,11 @@
 // Communicate with the user (status messages, yes/no questions, etc)
 // This class will proxy to either the GUI or cmdline functionality.
 
-
 using System;
 
 namespace CKAN
 {
-
+    public delegate int DisplaySelectionDialog(string message, params object[] args);
     public delegate void DisplayMessage(string message, params object[] args);
     public delegate bool DisplayYesNoDialog(string message);
     public delegate void DisplayError(string message, params object[] args);
@@ -16,21 +15,21 @@ namespace CKAN
     public interface IUser
     {
         event DisplayYesNoDialog AskUser;
+        event DisplaySelectionDialog AskUserForSelection;
         event DisplayMessage Message;
         event DisplayError Error;
         event ReportProgress Progress;
         event DownloadsComplete DownloadsComplete;
         int WindowWidth { get; }
-
         bool Headless { get; }
 
+        int RaiseSelectionDialog(string message, params object[] args);
         void RaiseMessage(string message, params object[] url);
         void RaiseProgress(string message, int percent);
         bool RaiseYesNoDialog(string question);
         void RaiseError(string message, params object[] args);
         void RaiseDownloadsCompleted(Uri[] file_urls, string[] file_paths, Exception[] errors);
     }
-
 
     //Can be used in tests to supress output or as a base class for other types of user.
     //It supplies no opp event handlers so that subclasses can avoid null checks. 
@@ -41,6 +40,7 @@ namespace CKAN
         public NullUser()
         {
             AskUser += DisplayYesNoDialog;
+            AskUserForSelection += DisplaySelectionDialog;
             Message += DisplayMessage;
             Error += DisplayError;
             Progress += ReportProgress;
@@ -48,6 +48,7 @@ namespace CKAN
         }
 
         public event DisplayYesNoDialog AskUser;
+        public event DisplaySelectionDialog AskUserForSelection;
         public event DisplayMessage Message;
         public event DisplayError Error;
         public event ReportProgress Progress;
@@ -67,6 +68,11 @@ namespace CKAN
         {
         }
 
+        protected virtual int DisplaySelectionDialog(string message, params object[] args)
+        {
+            return 0;
+        }
+
         protected virtual void DisplayError(string message, params object[] args)
         {
         }
@@ -77,8 +83,6 @@ namespace CKAN
         protected virtual void ReportDownloadsComplete(Uri[] urls, string[] filenames, Exception[] errors)
         {
         }
-
-
 
         public virtual int WindowWidth
         {
@@ -99,6 +103,11 @@ namespace CKAN
         {
             //Return value will be from last handler added.
             return AskUser(question);
+        }
+
+        public int RaiseSelectionDialog(string message, params object[] args)
+        {
+            return AskUserForSelection(message, args);
         }
 
         public void RaiseError(string message, params object[] args)

--- a/Win32Registry.cs
+++ b/Win32Registry.cs
@@ -8,7 +8,7 @@ namespace CKAN
     {
 
         string AutoStartInstance { get; set; }
-        void SetRegistryToInstances(Dictionary<string, KSP> instances, string auto_start_instance);
+        void SetRegistryToInstances(SortedList<string, KSP> instances, string auto_start_instance);
         IEnumerable<Tuple<string, string>> GetInstances();
     }
 
@@ -37,7 +37,7 @@ namespace CKAN
                 GetRegistryValue("KSPInstancePath_" + i, ""));
         }
 
-        public void SetRegistryToInstances(Dictionary<string, KSP> instances, string auto_start_instance)
+        public void SetRegistryToInstances(SortedList<string, KSP> instances, string auto_start_instance)
         {
             SetAutoStartInstance(auto_start_instance ?? "");
             SetNumberOfInstances(instances.Count);


### PR DESCRIPTION
When selecting a mod with several conflicting subdependencies, the GUI will ask the user to select one and continue, the CLI does not do this. This adds support for selecting one item from a list of items, and supports a preselected default.

This is part of the old PR at https://github.com/KSP-CKAN/CKAN/pull/586.