### PR TITLE
Do not pull in suggested/recommended when updating

### DIFF
--- a/ModuleInstaller.cs
+++ b/ModuleInstaller.cs
@@ -806,7 +806,7 @@ namespace CKAN
         {
             var options = new RelationshipResolverOptions();
 
-            // We do not wish to pull in any suggested or recommends mods.
+            // We do not wish to pull in any suggested or recommended mods.
             options.with_recommends = false;
             options.with_suggests = false;
 

--- a/ModuleInstaller.cs
+++ b/ModuleInstaller.cs
@@ -805,6 +805,11 @@ namespace CKAN
         public void Upgrade(IEnumerable<string> identifiers, NetAsyncDownloader netAsyncDownloader)
         {
             var options = new RelationshipResolverOptions();
+
+            // We do not wish to pull in any suggested or recommends mods.
+            options.with_recommends = false;
+            options.with_suggests = false;
+
             var resolver = new RelationshipResolver(identifiers.ToList(), options, registry_manager.registry, ksp.Version());
             List<CkanModule> upgrades = resolver.ModList();
 


### PR DESCRIPTION
When updating mods, do not attempt to pull in any suggested or recommended mods. This has shown to be an issue with https://github.com/KSP-CKAN/CKAN-support/issues/51.