### PR TITLE
Give repositories an order attribute

### DIFF
--- a/Net/Repo.cs
+++ b/Net/Repo.cs
@@ -79,14 +79,14 @@ namespace CKAN
         /// </summary>
         public static int UpdateAllRepositories(RegistryManager registry_manager, KSP ksp, IUser user)
         {
-            Dictionary<string, Uri> repositories = registry_manager.registry.Repositories;
-
             // If we handle multiple repositories, we will call ClearRegistry() ourselves...
             registry_manager.registry.ClearAvailable();
-            foreach (KeyValuePair<string, Uri> entry in repositories)
+            // TODO this should already give us a pre-sorted list
+            SortedDictionary<string, Repository> sortedRepositories = registry_manager.registry.Repositories;
+            foreach (KeyValuePair<string, Repository> repository in sortedRepositories)
             {
-                log.InfoFormat("About to update {0}", entry.Value);
-                UpdateRegistry(entry.Value, registry_manager.registry, ksp, user, false);
+                log.InfoFormat("About to update {0}", repository.Value.name);
+                UpdateRegistry(repository.Value.uri, registry_manager.registry, ksp, user, false);
             }
 
             // Return how many we got!

--- a/Registry/Registry.cs
+++ b/Registry/Registry.cs
@@ -26,7 +26,11 @@ namespace CKAN
 
         [JsonProperty] private int registry_version;
 
-        [JsonProperty] private Dictionary<string, Uri> repositories; // name => uri
+        // TODO the unsorted repositories are a legacy object for the old format, to be removed after a few releases
+        [JsonProperty("repositories")]
+        private Dictionary<string, Uri> unsortedRepositories; // name => uri
+        [JsonProperty("sorted_repositories")]
+        private SortedDictionary<string, Repository> repositories; // name => Repository
 
         // TODO: These may be good as custom types, especially those which process
         // paths (and flip from absolute to relative, and vice-versa).
@@ -38,9 +42,9 @@ namespace CKAN
         [JsonIgnore] private string transaction_backup;
 
         /// <summary>
-        /// Returns all the activated registries
+        /// Returns all the activated registries, sorted by priority and name
         /// </summary>
-        [JsonIgnore] public Dictionary<string, Uri> Repositories
+        [JsonIgnore] public SortedDictionary<string, Repository> Repositories
         {
             get { return this.repositories; }
 
@@ -163,7 +167,7 @@ namespace CKAN
             Dictionary<string, string> installed_dlls,
             Dictionary<string, AvailableModule> available_modules,
             Dictionary<string, string> installed_files,
-            Dictionary<string, Uri> repositories
+            SortedDictionary<string, Repository> repositories
             )
         {
             // Is there a better way of writing constructors than this? Srsly?
@@ -190,7 +194,7 @@ namespace CKAN
                 new Dictionary<string, string>(),
                 new Dictionary<string, AvailableModule>(),
                 new Dictionary<string, string>(),
-                new Dictionary<string, Uri>()
+                new SortedDictionary<string, Repository>()
                 );
         }
 

--- a/Registry/RegistryManager.cs
+++ b/Registry/RegistryManager.cs
@@ -111,17 +111,18 @@ namespace CKAN
 
         private void AscertainDefaultRepo()
         {
-            Dictionary<string, Uri> repositories = registry.Repositories;
+            SortedDictionary<string, Repository> repositories = registry.Repositories;
 
             if (repositories == null)
             {
-                repositories = new Dictionary<string, Uri>();
+                repositories = new SortedDictionary<string, Repository>();
             }
 
             // if (!(repositories.ContainsKey(Repository.default_ckan_repo_name)))
             if (repositories.Count == 0)
             {
-                repositories.Add(Repository.default_ckan_repo_name, Repository.default_ckan_repo_uri);
+                repositories.Add(Repository.default_ckan_repo_name,
+                    new Repository(Repository.default_ckan_repo_name, Repository.default_ckan_repo_uri));
             }
 
             registry.Repositories = repositories;

--- a/Types/Repository.cs
+++ b/Types/Repository.cs
@@ -11,15 +11,28 @@ namespace CKAN
 
         public string name;
         public Uri uri;
+        public int priority = 0;
         public Boolean ckan_mirror = false;
 
         public Repository()
         {
         }
 
+        public Repository(string name, string uri)
+        {
+            this.name = name;
+            this.uri = new Uri(uri);
+        }
+
+        public Repository(string name, Uri uri)
+        {
+            this.name = name;
+            this.uri = uri;
+        }
+
         public override string ToString()
         {
-            return String.Format("{0} ({1})", name, uri.DnsSafeHost);
+            return String.Format("{0} ({1}, {2})", name, priority, uri.ToString());
         }
     }
 


### PR DESCRIPTION
This makes it possible to order repositories, instead of going just by alphabetical name.

Pull requests against CKAN-cmdline and CKAN-GUI to handle the new datatype will come immediately afterwards.