### PR TITLE
Implements metapackages in core

### DIFF
--- a/ModuleInstaller.cs
+++ b/ModuleInstaller.cs
@@ -275,6 +275,8 @@ namespace CKAN
 
         private void Install(CkanModule module, string filename = null)
         {
+            CheckMetapackageInstallationKraken(module);
+
             Version version = registry_manager.registry.InstalledVersion(module.identifier);
 
             // TODO: This really should be handled by higher-up code.
@@ -321,6 +323,18 @@ namespace CKAN
             }
 
         }
+
+        /// <summary>
+        /// Check if the given module is a metapackage:
+        /// if it is, throws a BadCommandKraken.
+        /// </summary>
+        private static void CheckMetapackageInstallationKraken(CkanModule module)
+        {
+            if (module.IsMetapackage)
+            {
+                throw new BadCommandKraken("Metapackages can not be installed!");
+            }
+        }
             
         /// <summary>
         /// Installs the module from the zipfile provided.
@@ -330,6 +344,8 @@ namespace CKAN
         /// </summary>
         private IEnumerable<string> InstallModule(CkanModule module, string zip_filename)
         {
+            CheckMetapackageInstallationKraken(module);
+
             using (ZipFile zipfile = new ZipFile(zip_filename))
             {
                 IEnumerable<InstallableFile> files = FindInstallableFiles(module, zipfile, ksp);

--- a/Relationships/RelationshipResolver.cs
+++ b/Relationships/RelationshipResolver.cs
@@ -240,6 +240,9 @@ namespace CKAN
         /// </summary>
         private void Add(CkanModule module)
         {
+            if (module.IsMetapackage)
+                return;
+
             log.DebugFormat("Adding {0} {1}", module.identifier, module.version);
 
             if (modlist.ContainsKey(module.identifier))

--- a/Types/Module.cs
+++ b/Types/Module.cs
@@ -47,6 +47,10 @@ namespace CKAN
         [JsonProperty("description")]
         public string description;
 
+        // Package type: in spec v1.6 can be either "package" or "metapackage"
+        [JsonProperty("kind")]
+        public string kind;
+
         [JsonProperty("author")]
         [JsonConverter(typeof(JsonSingleOrArrayConverter<string>))]
         public List<string> author;
@@ -224,6 +228,15 @@ namespace CKAN
         {
             return this.identifier == identifier || provides.Contains(identifier);
         }
+
+        public bool IsMetapackage
+        {
+            get
+            {
+                return (!string.IsNullOrEmpty(this.kind) && this.kind == "metapackage");
+            }
+        }
+
     }
 
     public class CkanModule : Module

--- a/Types/Module.cs
+++ b/Types/Module.cs
@@ -377,6 +377,9 @@ namespace CKAN
 
                 if (value == null)
                 {
+                    // Metapackages are allowed to have no download field
+                    if (field == "download" && newModule.IsMetapackage) continue;
+
                     string error = String.Format("{0} missing required field {1}", newModule.identifier, field);
 
                     log.Error(error);


### PR DESCRIPTION
This allows the core to handle metapackages.
A metapackage is just any normal ckan module that has `kind: metapackage` (see KSP-CKAN/CKAN#772 and KSP-CKAN/CKAN-core#63).

The download field is ignored for these packages.
The metapackage itself is *not* installed: it just acts as a list of mods (`depends`, `suggests` and `recommends` still work perfectly fine).

This PR needs  KSP-CKAN/CKAN#772 to be merged first.