### PR TITLE
Tweaked ResolveStanza() to always pick a candidate

### DIFF
--- a/Relationships/RelationshipResolver.cs
+++ b/Relationships/RelationshipResolver.cs
@@ -182,16 +182,10 @@ namespace CKAN
                     log.InfoFormat("{0} is recommended/suggested, but nothing provides it.", dep_name);
                     continue;
                 }
-                if (candidates.Count > 1)
+                // Only throw TooManyModsProvideKraken if too many candidates and 
+                // if we actually care that there are too many candidates
+                if (candidates.Count > 1 && !options.without_toomanyprovides_kraken)
                 {
-                    // Oh no, too many to pick from!
-                    // TODO: It would be great if instead we picked the one with the
-                    // most recommendations.
-                    if (options.without_toomanyprovides_kraken)
-                    {
-                        continue;
-                    }
-
                     throw new TooManyModsProvideKraken(dep_name, candidates);
                 }
 


### PR DESCRIPTION
Previously, in --headless mode ResolveStanza would skip a mod if more than 2
candidates provided the same thing, such as RSSTextures being provided by 6
different packages. This hopefully changes that so when in --headless mode the
first option is always picked, making sure --headless installs are never
inconsistent. This hopefully will eliminate false negatives for pull request
tests.

Not 100% sure this is the right fix though, since --headless seemed to work fine
when there were only two options, despite the code implying candidate selection
would be skipped if there were two or more options. Almost certainly missing
something.... Wish I had the right system to try it out.