### PR TITLE
Use original string when downloading using libcurl

### DIFF
--- a/Net/Curl.cs
+++ b/Net/Curl.cs
@@ -81,7 +81,10 @@ namespace CKAN
 
         public static CurlEasy CreateEasy(Uri url, FileStream stream)
         {
-            return CreateEasy(url.ToString(), stream);
+            // Curl interacts poorly with KS for some (but not all) modules unless
+            // the original string is used, hence .OriginalString rather than .ToString
+            // here.
+            return CreateEasy(url.OriginalString, stream);
         }
     }
 }

--- a/Tests/CKAN/Types/Module.cs
+++ b/Tests/CKAN/Types/Module.cs
@@ -32,6 +32,19 @@ namespace CKANTests
             Assert.AreEqual("https://github.com/KSP-KOS/KOS/issues", module.resources.bugtracker.ToString());
         }
 
+        /// <summary>
+        /// There's a condition where some mods won't download if the server is presented with
+        /// an unescaped string, but *will* if passed an escaped string. This isn't the case with
+        /// all servers and mods, but in any case we check that our original string is always
+        /// available after Url-ification so we can use it.
+        /// </summary>
+        [Test]
+        public void SpacesPreservedInDownload()
+        {
+            CkanModule module = CkanModule.FromJson(TestData.DogeCoinFlag_101());
+            Assert.AreEqual("https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01", module.download.OriginalString);
+        }
+
         [Test]
         public void FilterRead()
         {

--- a/Tests/TestData.cs
+++ b/Tests/TestData.cs
@@ -183,6 +183,49 @@ namespace Tests
             ";
         }
 
+        /// <summary>
+        /// Taurus HCV pod, which seems to cause weird KS errors when the unescaped
+        /// download string is used.
+        /// </summary>
+        public static string RandSCapsuleDyne()
+        {
+            return @"
+                {
+                    ""spec_version"": 1,
+                    ""name"": ""Taurus HCV - 3.75 m Stock-ish Crew Pod"",
+                    ""identifier"": ""RandSCapsuledyne"",
+                    ""license"": ""CC-BY-SA-3.0"",
+                    ""install"": [
+                        {
+                            ""file"": ""GameData/R&SCapsuledyne"",
+                            ""install_to"": ""GameData""
+                        }
+                    ],
+                    ""depends"": [
+                        {
+                            ""name"": ""BDAnimationModules""
+                        }
+                    ],
+                    ""resources"": {
+                        ""homepage"": ""http://forum.kerbalspaceprogram.com/threads/75074-Taurus-HCV-3-75-m-Stock-ish-Crew-Pod-v-b0-5-April-4-2014?p=1064792#post1064792"",
+                        ""kerbalstuff"": ""https://kerbalstuff.com/mod/13/Taurus%20HCV%20-%203.75%20m%20Stock-ish%20Crew%20Pod""
+                    },
+                    ""ksp_version"": ""0.90"",
+                    ""abstract"": ""0.90.0 COMPATIBLE! The Taurus High Capacity Vehicle is a 7 kerbal, 3.75-m cockpit designed to integrate well with the stock game. "",
+                    ""author"": ""jnrobinson"",
+                    ""version"": ""1.4.0"",
+                    ""download"": ""https://kerbalstuff.com/mod/13/Taurus%20HCV%20-%203.75%20m%20Stock-ish%20Crew%20Pod/download/1.4.0"",
+                    ""x_generated_by"": ""netkan"",
+                    ""download_size"": 8351916
+                }
+            ";
+        }
+
+        public static CkanModule RandSCapsuleDyneModule()
+        {
+            return CkanModule.FromJson(RandSCapsuleDyne());
+        }
+
         public static Uri TestKAN()
         {
             return new Uri("../../../Tests/DATA/CKAN-meta-testkan.zip", UriKind.Relative);


### PR DESCRIPTION
For some reason *most* mods on KS are fine if the URL is presented as
"URL with spaces" or "URL%20with%20spaces". However some (R&S
CapsuleDyne in particualar) are not.

I have no idea why.

Luckily, the solution here is easy; we just make sure Curl always uses
the original download string.

This comes with a one line change, and a bunch of test improvements that
allowed me to reach the ability to make a one line change. :)