### PR TITLE
Curl is less picky about SSL certs.

### DIFF
--- a/Net/Curl.cs
+++ b/Net/Curl.cs
@@ -63,6 +63,11 @@ namespace CKAN
             easy.Encoding = "deflate, gzip";
             easy.FollowLocation = true; // Follow redirects
             easy.UserAgent = Net.UserAgentString;
+
+            // At least ksp.sarbian.com uses a SSL cert that libcurl can't
+            // verify, so we skip verification. Yeah, that sucks, I know.
+            easy.SslVerifyPeer = false;
+
             return easy;
         }
 


### PR DESCRIPTION
Yeah, this sucks, with this change we're no longer doing a full
certificate check, which reduces the value of SSL.

On the other hand, this change means folks can download from sites
like ksp.sarbian.com that use certificates from authorities that
don't seem to be recognised by libcurl.

A better change in the future would be to provide some of our own
CAs as well, provide our own mirror that CKAN falls back to, or
something else. But for now, we're doing this awful thing. :/