### PR TITLE
Ughn. Have Net.Download always pass the original string.

### DIFF
--- a/Net/Net.cs
+++ b/Net/Net.cs
@@ -29,7 +29,7 @@ namespace CKAN
         /// </summary>
         public static string Download(Uri url, string filename = null, IUser user = null)
         {
-            return Download(url.ToString(), filename, user);
+            return Download(url.OriginalString, filename, user);
         }
 
         public static string Download(string url, string filename = null, IUser user = null)


### PR DESCRIPTION
This apparently is *also* needed for KSP-CKAN/CKAN-Netkan#46