### PR TITLE
Revert "Add github token for update requests"

### DIFF
--- a/Net/AutoUpdate.cs
+++ b/Net/AutoUpdate.cs
@@ -95,7 +95,7 @@ namespace CKAN
         {
             var web = new WebClient();
             web.Headers.Add("user-agent", Net.UserAgentString);
-            web.Headers.Add("Authorization", String.Format("token {0}", "b0dc75815795c82a4bc8f295371868331fdb1555"));
+
             string result = "";
             try
             {


### PR DESCRIPTION
I have *no idea* why we've got a github token compiled into our code.

* Reverts commit d82f3c4651db8577270e1f4bf8b0f2f9d0e25904.
* Reverts PR #83.
* Closes KSP-CKAN/CKAN-support#113.