### PR TITLE
Enable install of incompatible mods, and set KspVersion to return string "Any" when version is null.

### DIFF
--- a/ModuleInstaller.cs
+++ b/ModuleInstaller.cs
@@ -152,7 +152,7 @@ namespace CKAN
             NetAsyncDownloader downloader = null
         )
         {
-            var resolver = new RelationshipResolver(modules, options, registry_manager.registry, ksp.Version());
+            var resolver = new RelationshipResolver(modules, options, registry_manager.registry, null);
             List<CkanModule> modsToInstall = resolver.ModList();
 
             InstallList(modsToInstall, options, downloader = null);
@@ -174,7 +174,7 @@ namespace CKAN
             NetAsyncDownloader downloader = null
         )
         {            
-            var resolver = new RelationshipResolver(modules, options, registry_manager.registry, ksp.Version());
+            var resolver = new RelationshipResolver(modules, options, registry_manager.registry, null);
             List<CkanModule> modsToInstall = resolver.ModList();
             List<CkanModule> downloads = new List<CkanModule> (); 
 

--- a/Registry/Registry.cs
+++ b/Registry/Registry.cs
@@ -498,6 +498,20 @@ namespace CKAN
             }
         }
 
+
+        /// <summary>
+        /// Checks whether the mod specified by string ID is compatible with the specified KSP version.
+        /// </summary>
+        /// <param name="module">String ID of the mod (name).</param>
+        /// <param name="ksp_version">KSP version to check against.</param>
+        /// <returns></returns>
+        public bool IsModCompatible(string module, KSPVersion ksp_version)
+        {
+            CkanModule mod = available_modules[module].Latest(ksp_version);
+
+            return (mod != null);
+        }
+
         /// <summary>
         ///     Returns the latest available version of a module that
         ///     satisifes the specified version. Takes into account module 'provides',

--- a/Tests/CKAN/Types/KSPVersion.cs
+++ b/Tests/CKAN/Types/KSPVersion.cs
@@ -37,7 +37,7 @@ namespace CKANTests
             var vshort = new CKAN.KSPVersion("0.23");
             var vlong = new CKAN.KSPVersion("0.23.5");
 
-            Assert.AreSame(any.ToString(), null);
+            Assert.AreSame(any.ToString(), "Any");
             Assert.AreSame(vshort.ToString(), "0.23");
             Assert.AreSame(vlong.ToString(), "0.23.5");
         }

--- a/Types/KSPVersion.cs
+++ b/Types/KSPVersion.cs
@@ -64,16 +64,25 @@ namespace CKAN {
             return version != null && Regex.IsMatch (version, @"^\d+\.\d+\.\d+$");
         }
 
-        public bool IsAny() {
-            return version == null;
+        public bool IsAny() 
+        {
+            return (version == null || version.Equals("any", StringComparison.InvariantCultureIgnoreCase));
         }
 
         public bool IsNotAny() {
             return ! IsAny ();
         }
 
-        public string Version() {
-            return version;
+        public string Version() 
+        {
+            if (version == null || version == "")
+            {
+                return "Any";
+            }
+            else
+            {
+                return version;
+            }
         }
 
         // Private for now, since we can't guarnatee public code will only call
@@ -131,8 +140,10 @@ namespace CKAN {
         }
 
         // "any" -> null
-        private static string AnyToNull(string v) {
-            if (v != null && v == "any") {
+        private static string AnyToNull(string v) 
+        {
+            if (v != null && v.Equals("any", StringComparison.InvariantCultureIgnoreCase))
+            {
                 return null;
             }
             return v;
@@ -140,7 +151,7 @@ namespace CKAN {
 
         // Throws on error.
         private void Validate() {
-            if (version == null || IsShortVersion() || IsLongVersion()) {
+            if (IsShortVersion() || IsLongVersion() || IsAny()) {
                 return;
             }
             throw new BadKSPVersionException (version);


### PR DESCRIPTION
Hi, long time user, first time submitter.  Please review.  

Made a couple of minor changes.  Purpose:

   - Changed KspVersion to support GUI changes that adds target KSP version to the UI.
   - Changed relationship resolver calls that let the user install mods targeted to a different version.  GUI will pop up a dialog asking the user whether he really wants to install an incompatible version.