### PR TITLE
Changed hash function from private to public.

### DIFF
--- a/Net/NetFileCache.cs
+++ b/Net/NetFileCache.cs
@@ -183,7 +183,7 @@ namespace CKAN
         }
 
         // returns the 8-byte hash for a given url
-        private static string CreateURLHash(Uri url)
+        public static string CreateURLHash(Uri url)
         {
             using (var sha1 = new SHA1Managed())
             {


### PR DESCRIPTION
For use in a PR for cmdline (https://github.com/KSP-CKAN/CKAN-cmdline/pull/60). Relevant for https://github.com/KSP-CKAN/CKAN-core/issues/101.