### PR TITLE
Lower "not removing directory" messages to info level.

### DIFF
--- a/ModuleInstaller.cs
+++ b/ModuleInstaller.cs
@@ -784,7 +784,7 @@ namespace CKAN
                     }
                     else
                     {
-                        User.RaiseMessage("Not removing directory {0}, it's not empty", directory);
+                        log.InfoFormat("Not removing directory {0}, it's not empty", directory);
                     }
                 }
                 transaction.Complete();


### PR DESCRIPTION
Users think that "not removing directory" messages are an error. They're not. This change lowers their priority to info, so they'll be visible when running under `--verbose`, but suppressed otherwise.

Closes KSP-CKAN/CKAN-support#138.