### PR TITLE
Relationship resolver rework

### DIFF
--- a/KSPManager.cs
+++ b/KSPManager.cs
@@ -21,7 +21,7 @@ namespace CKAN
 
         private readonly SortedList<string, KSP> instances = new SortedList<string, KSP>();
 
-        internal string AutoStartInstance
+        public string AutoStartInstance
         {
             get { return Win32Registry.AutoStartInstance; }
             private set

--- a/Registry/Registry.cs
+++ b/Registry/Registry.cs
@@ -846,6 +846,17 @@ namespace CKAN
         }
 
         /// <summary>
+        /// Gets the installed version of a mod. Returns null if provided or autodetected. 
+        /// </summary>
+        /// <param name="mod_identifer"></param>
+        /// <returns></returns>
+        public Module GetInstalledVersion(string mod_identifer)
+        {
+            InstalledModule installedModule;
+            return installed_modules.TryGetValue(mod_identifer, out installedModule) ? installedModule.Module : null;
+        }
+
+        /// <summary>
         ///     Check if a mod is installed (either via CKAN, DLL, or virtually)
         /// </summary>
         /// <returns><c>true</c>, if installed<c>false</c> otherwise.</returns>

--- a/Relationships/RelationshipResolver.cs
+++ b/Relationships/RelationshipResolver.cs
@@ -208,6 +208,7 @@ namespace CKAN
             foreach (var module in mods)
             {
                 installed_modules.Remove(module);
+                conflicts.RemoveAll(kvp => kvp.Key.Equals(module) || kvp.Value.Equals(module));
             }
         }
 

--- a/Relationships/RelationshipResolver.cs
+++ b/Relationships/RelationshipResolver.cs
@@ -57,7 +57,7 @@ namespace CKAN
     }
 
     // TODO: RR currently conducts a depth-first resolution of requirements. While we do the
-    // right thing in processing all depdenencies first, then recommends, and then suggests,
+    // right thing in processing all dependencies first, then recommends, and then suggests,
     // we could find that a recommendation many layers deep prevents a recommendation in the
     // original mod's recommends list.
     //
@@ -66,6 +66,14 @@ namespace CKAN
 
     // TODO: Add mechanism so that clients can add mods with relationshup other than UserAdded. 
     // Currently only made to support the with_{} options. 
+
+
+    /// <summary>
+    /// A class used to resolve relationships between mods. Primarily used to satisfy missing dependencies and to check for conflicts on proposed installs. 
+    /// </summary>
+    /// <remarks>
+    /// All constructors start with currently installed modules, to remove <see cref="RelationshipResolver.RemoveModsFromInstalledList" />  
+    /// </remarks>
     public class RelationshipResolver
     {
         // A list of all the mods we're going to install.
@@ -74,15 +82,20 @@ namespace CKAN
         private readonly List<CkanModule> user_requested_mods = new List<CkanModule>();
         private readonly List<KeyValuePair<Module, Module>> conflicts = 
             new List<KeyValuePair<Module, Module>>();
-        private readonly Dictionary<Module, Relationship> reasons = 
-            new Dictionary<Module, Relationship>(new Module.IdentifierEqualilty());
+        private readonly Dictionary<Module, SelectionReason> reasons = 
+            new Dictionary<Module, SelectionReason>(new Module.IdentifierEqualilty());
 
         private readonly Registry registry;
         private readonly KSPVersion kspversion;
         private readonly RelationshipResolverOptions options;
         private readonly HashSet<Module> installed_modules;
 
-
+        /// <summary>
+        /// Creates a new Relationship resolver.
+        /// </summary>
+        /// <param name="options"><see cref="RelationshipResolverOptions"/></param>
+        /// <param name="registry">The registry to use</param>
+        /// <param name="kspversion">The version of the install that the registry corresponds to</param>
         public RelationshipResolver(RelationshipResolverOptions options, Registry registry, KSPVersion kspversion)
         {
             this.registry = registry;
@@ -90,13 +103,20 @@ namespace CKAN
             this.options = options;
 
             installed_modules = new HashSet<Module>(registry.InstalledModules.Select(i_module => i_module.Module));
-            var installed_relationship = new Relationship.Installed();
+            var installed_relationship = new SelectionReason.Installed();
             foreach (var module in installed_modules)
             {
                 reasons.Add(module, installed_relationship);
             }
         }
 
+        /// <summary>
+        /// Attempts to convert the module_names to ckan modules via  CkanModule.FromIDandVersion and then calls RelationshipResolver.ctor(IEnumerable{CkanModule}, Registry, KSPVersion)"/>
+        /// </summary>
+        /// <param name="module_names"></param>
+        /// <param name="options"></param>
+        /// <param name="registry"></param>
+        /// <param name="kspversion"></param>
         public RelationshipResolver(IEnumerable<string> module_names, RelationshipResolverOptions options, Registry registry,
             KSPVersion kspversion) :
                 this(module_names.Select(name => CkanModule.FromIDandVersion(registry, name, kspversion)).ToList(),
@@ -104,13 +124,13 @@ namespace CKAN
                     registry,
                     kspversion)
         {
-            // Does nothing, just calles the other overloaded constructor
+            // Does nothing, just calls the other overloaded constructor
         }
        
         /// <summary>
         /// Creates a new resolver that will find a way to install all the modules specified.
         /// </summary>
-        public RelationshipResolver(ICollection<CkanModule> modules, RelationshipResolverOptions options, Registry registry,
+        public RelationshipResolver(IEnumerable<CkanModule> modules, RelationshipResolverOptions options, Registry registry,
             KSPVersion kspversion):this(options,registry,kspversion)
         {
             AddModulesToInstall(modules);
@@ -139,12 +159,11 @@ namespace CKAN
         /// to installed mods and is intended to be used when this is incorrect, such as when some are to be 
         /// removed.         
         /// </summary>
-        /// <param name="modules">Modules to checkattempt to install</param>
-        /// <param name="installed_modules">Currently installed modules to consider</param>
+        /// <param name="modules">Modules to attempt to install</param>        
         public void AddModulesToInstall(IEnumerable<CkanModule> modules)
         {                        
             //Count may need to do a full enumeration. Might as well convert to array
-            var ckan_modules = modules as CkanModule[] ?? modules.ToArray();
+            var ckan_modules = modules as CkanModule[] != null ? modules as CkanModule[] : modules.ToArray();
             log.DebugFormat("Processing relationships for {0} modules", ckan_modules.Count());
 
             // Start by figuring out what versions we're installing, and then
@@ -155,7 +174,7 @@ namespace CKAN
             {
                 log.DebugFormat("Preparing to resolve relationships for {0} {1}", module.identifier, module.version);
 
-                //Need to check againt installed mods and those to install. 
+                //Need to check against installed mods and those to install. 
                 var mods = modlist.Values.Concat(installed_modules).Where(listed_mod => listed_mod.ConflictsWith(module));
                 foreach (var listed_mod in mods)
                 {
@@ -172,10 +191,10 @@ namespace CKAN
                 }
 
                 user_requested_mods.Add(module);
-                Add(module, new Relationship.UserRequested());
+                Add(module, new SelectionReason.UserRequested());
             }
 
-            // Now that we've already pre-populated modlist, we can resolve
+            // Now that we've already pre-populated the modlist, we can resolve
             // the rest of our dependencies.
 
             foreach (var module in user_requested_mods)
@@ -200,7 +219,7 @@ namespace CKAN
 
         /// <summary>
         /// Removes mods from the list of installed modules. Intended to be used for cases 
-        /// in which the mod is to be uninstalled.
+        /// in which the mod is to be un-installed.
         /// </summary>
         /// <param name="mods">The mods to remove.</param>
         public void RemoveModsFromInstalledList(IEnumerable<Module> mods)
@@ -225,18 +244,18 @@ namespace CKAN
             sub_options.with_suggests = false;
 
             log.DebugFormat("Resolving dependencies for {0}", module.identifier);
-            ResolveStanza(module.depends, new Relationship.Depends(module), sub_options);
+            ResolveStanza(module.depends, new SelectionReason.Depends(module), sub_options);
 
             if (options.with_recommends)
             {
                 log.DebugFormat("Resolving recommends for {0}", module.identifier);
-                ResolveStanza(module.recommends, new Relationship.Recommended(module), sub_options, true);
+                ResolveStanza(module.recommends, new SelectionReason.Recommended(module), sub_options, true);
             }
 
             if (options.with_suggests || options.with_all_suggests)
             {
                 log.DebugFormat("Resolving suggests for {0}", module.identifier);
-                ResolveStanza(module.suggests, new Relationship.Suggested(module), sub_options, true);
+                ResolveStanza(module.suggests, new SelectionReason.Suggested(module), sub_options, true);
             }
         }
 
@@ -255,7 +274,7 @@ namespace CKAN
         ///
         /// </summary>
 
-        private void ResolveStanza(IEnumerable<RelationshipDescriptor> stanza, Relationship reason,
+        private void ResolveStanza(IEnumerable<RelationshipDescriptor> stanza, SelectionReason reason,
             RelationshipResolverOptions options, bool soft_resolve = false)
         {
             if (stanza == null)
@@ -334,7 +353,7 @@ namespace CKAN
         /// Adds the specified module to the list of modules we're installing.
         /// This also adds its provides list to what we have available.
         /// </summary>
-        private void Add(CkanModule module, Relationship reason)
+        private void Add(CkanModule module, SelectionReason reason)
         {
             if (module.IsMetapackage)
                 return;
@@ -370,7 +389,7 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Returns a list of all modules to install to satisify the changes required.
+        /// Returns a list of all modules to install to satisfy the changes required.
         /// </summary>
         public List<CkanModule> ModList()
         {
@@ -404,7 +423,7 @@ namespace CKAN
             get { return !conflicts.Any(); }
         }
 
-        internal Relationship ReasonFor(CkanModule mod)
+        internal SelectionReason ReasonFor(CkanModule mod)
         {
             if (!ModList().Contains(mod))
             {
@@ -427,8 +446,8 @@ namespace CKAN
             }
 
             var reason = reasons[mod];
-            var is_root_type = reason.GetType() == typeof (Relationship.UserRequested) 
-                || reason.GetType() == typeof(Relationship.Installed);
+            var is_root_type = reason.GetType() == typeof (SelectionReason.UserRequested) 
+                || reason.GetType() == typeof(SelectionReason.Installed);
             return is_root_type
                 ? reason.Reason
                 : reason.Reason + ReasonStringFor(reason.Parent);
@@ -439,7 +458,7 @@ namespace CKAN
     /// Used to keep track of the relationships between modules in the resolver. 
     /// Intended to be used for displaying messages to the user.     
     /// </summary>
-    internal abstract class Relationship
+    internal abstract class SelectionReason
     {
         //Currently assumed to exist for any relationship other than useradded or installed
         public virtual CkanModule Parent { get; protected set; }
@@ -447,7 +466,7 @@ namespace CKAN
         public abstract String Reason { get; }       
 
 
-        public class Installed : Relationship
+        public class Installed : SelectionReason
         {
             public override CkanModule Parent
             {
@@ -464,7 +483,7 @@ namespace CKAN
             }            
         }
 
-        public class UserRequested : Relationship
+        public class UserRequested : SelectionReason
         {
             public override CkanModule Parent
             {
@@ -481,7 +500,7 @@ namespace CKAN
             }
         }
 
-        public sealed class Suggested : Relationship
+        public sealed class Suggested : SelectionReason
         {
             public Suggested(CkanModule module)
             {
@@ -495,7 +514,7 @@ namespace CKAN
             }
         }
 
-        public sealed class Depends : Relationship
+        public sealed class Depends : SelectionReason
         {
             public Depends(CkanModule module)
             {
@@ -509,7 +528,7 @@ namespace CKAN
             }
         }
 
-        public sealed class Recommended : Relationship
+        public sealed class Recommended : SelectionReason
         {
             public Recommended(CkanModule module)
             {

--- a/Relationships/RelationshipResolver.cs
+++ b/Relationships/RelationshipResolver.cs
@@ -70,49 +70,95 @@ namespace CKAN
         // A list of all the mods we're going to install.
         private static readonly ILog log = LogManager.GetLogger(typeof (RelationshipResolver));
         private readonly Dictionary<string, CkanModule> modlist = new Dictionary<string, CkanModule>();
-
+        private readonly List<CkanModule> user_requested_mods = new List<CkanModule>();
         private readonly List<KeyValuePair<Module, Module>> conflicts =
             new List<KeyValuePair<Module, Module>>();
+        private readonly Dictionary<Module, Relationship> reasons = new Dictionary<Module, Relationship>(new Module.IdentifierEqualilty());
 
-        private readonly Dictionary<Module, Relationship> reasons = new Dictionary<Module, Relationship>();
         private readonly Registry registry;
         private readonly KSPVersion kspversion;
+        private readonly RelationshipResolverOptions options;
+        private IEnumerable<Module> installed;
 
 
-        public RelationshipResolver(ICollection<string> moduleNames, RelationshipResolverOptions options, Registry registry,
+        public RelationshipResolver(RelationshipResolverOptions options, Registry registry, KSPVersion kspversion)
+        {
+            this.registry = registry;
+            this.kspversion = kspversion;
+            this.options = options;
+        }
+
+        public RelationshipResolver(IEnumerable<string> module_names, RelationshipResolverOptions options, Registry registry,
             KSPVersion kspversion) :
-                this(moduleNames.Select(name => CkanModule.FromIDandVersion(registry, name, kspversion)).ToList(),
+                this(module_names.Select(name => CkanModule.FromIDandVersion(registry, name, kspversion)).ToList(),
                     options,
                     registry,
                     kspversion)
         {
             // Does nothing, just calles the other overloaded constructor
         }
-
+       
         /// <summary>
         /// Creates a new resolver that will find a way to install all the modules specified.
         /// </summary>
         public RelationshipResolver(ICollection<CkanModule> modules, RelationshipResolverOptions options, Registry registry,
-            KSPVersion kspversion)
+            KSPVersion kspversion):this(options,registry,kspversion)
         {
-            this.registry = registry;
-            this.kspversion = kspversion;
+            AddModulesToInstall(modules);
+        }
+
+        /// <summary>
+        ///     Returns the default options for relationship resolution.
+        /// </summary>
+        
+        // TODO: This should just be able to return a new RelationshipResolverOptions
+        // and the defaults in the class definition should do the right thing.
+        public static RelationshipResolverOptions DefaultOpts()
+        {
+            var opts = new RelationshipResolverOptions
+            {
+                with_recommends = true,
+                with_suggests = false,
+                with_all_suggests = false
+            };
+
+            return opts;
+        }
+
+        /// <summary>
+        /// Add modules to consideration of the relationship resolver. Optional installed parameter defaults
+        /// to installed mods and is intended to be used when this is incorrect, such as when some are to be 
+        /// removed.         
+        /// </summary>
+        /// <param name="modules">Modules to checkattempt to install</param>
+        /// <param name="installed_modules">Currently installed modules to consider</param>
+        public void AddModulesToInstall(IEnumerable<CkanModule> modules, IEnumerable<Module> installed_modules = null)
+        {                        
+            if (installed_modules == null)
+            {
+                installed = installed_modules = registry.InstalledModules.Select(i_module => i_module.Module).ToArray();
+            }
+
+            var installed_relationship = new Relationship.Installed();
+            foreach (var module in installed_modules)
+            {
+                reasons.Add(module, installed_relationship);
+            }
+            //Count may need to do a full enumeration. Might as well convert to array
+            var ckan_modules = modules as CkanModule[] ?? modules.ToArray();
+            log.DebugFormat("Processing relationships for {0} modules", ckan_modules.Count());
 
             // Start by figuring out what versions we're installing, and then
             // adding them to the list. This *must* be pre-populated with all
             // user-specified modules, as they may be supplying things that provide
             // virtual packages.
-
-            var user_requested_mods = new List<CkanModule>();
-
-            log.DebugFormat("Processing relationships for {0} modules", modules.Count);
-
-            foreach (CkanModule module in modules)
+            foreach (var module in ckan_modules)
             {
                 log.DebugFormat("Preparing to resolve relationships for {0} {1}", module.identifier, module.version);
 
-                var module1 = module; //Silence a warning re. closures over foreach var. 
-                foreach (CkanModule listed_mod in modlist.Values.Where(listed_mod => listed_mod.ConflictsWith(module1)))
+                //Need to check againt installed mods and those to install. 
+                var mods = modlist.Values.Concat(installed_modules).Where(listed_mod => listed_mod.ConflictsWith(module));
+                foreach (var listed_mod in mods)
                 {
                     if (options.procede_with_inconsistencies)
                     {
@@ -133,41 +179,24 @@ namespace CKAN
             // Now that we've already pre-populated modlist, we can resolve
             // the rest of our dependencies.
 
-            foreach (CkanModule module in user_requested_mods)
+            foreach (var module in user_requested_mods)
             {
                 log.InfoFormat("Resolving relationships for {0}", module.identifier);
                 Resolve(module, options);
             }
 
             var final_modules = new List<Module>(modlist.Values);
-            final_modules.AddRange(registry.InstalledModules.Select(x => x.Module));
+            
 
             if (!options.without_enforce_consistency)
             {
+                final_modules.AddRange(installed_modules);
                 // Finally, let's do a sanity check that our solution is actually sane.
                 SanityChecker.EnforceConsistency(
                     final_modules,
                     registry.InstalledDlls
                     );
             }
-        }
-
-        /// <summary>
-        ///     Returns the default options for relationship resolution.
-        /// </summary>
-        
-        // TODO: This should just be able to return a new RelationshipResolverOptions
-        // and the defaults in the class definition should do the right thing.
-        public static RelationshipResolverOptions DefaultOpts()
-        {
-            var opts = new RelationshipResolverOptions
-            {
-                with_recommends = true,
-                with_suggests = false,
-                with_all_suggests = false
-            };
-
-            return opts;
         }
 
         /// <summary>
@@ -258,7 +287,7 @@ namespace CKAN
                 // list thus far, as well as everything on the system.
 
                 var fixed_mods = new HashSet<Module>(modlist.Values);
-                fixed_mods.UnionWith(registry.InstalledModules.Select(x => x.Module));
+                fixed_mods.UnionWith(installed);
 
                 var conflicting_mod = fixed_mods.FirstOrDefault(mod => mod.ConflictsWith(candidate));
                 if (conflicting_mod == null)
@@ -306,7 +335,7 @@ namespace CKAN
                 throw new ArgumentException("Already contains module:" + module.identifier);
             }
             modlist.Add(module.identifier, module);
-            reasons.Add(module, reason);
+            if(!reasons.ContainsKey(module)) reasons.Add(module, reason);
 
             log.DebugFormat("Added {0}", module.identifier);
             // Stop here if it doesn't have any provide aliases.
@@ -385,7 +414,9 @@ namespace CKAN
             }
 
             var reason = reasons[mod];
-            return reason.GetType() == typeof (Relationship.UserRequested)
+            var is_root_type = reason.GetType() == typeof (Relationship.UserRequested) 
+                || reason.GetType() == typeof(Relationship.Installed);
+            return is_root_type
                 ? reason.Reason
                 : reason.Reason + ReasonStringFor(reason.Parent);
         }
@@ -397,11 +428,28 @@ namespace CKAN
     /// </summary>
     internal abstract class Relationship
     {
-        //Currently assumed to exist for any relationship other than useradded
+        //Currently assumed to exist for any relationship other than useradded or installed
         public virtual CkanModule Parent { get; protected set; }
         //Should contain a newline at the end of the string. 
-        public abstract String Reason { get; }
+        public abstract String Reason { get; }       
 
+
+        public class Installed : Relationship
+        {
+            public override CkanModule Parent
+            {
+                get
+                {
+                    Debug.Assert(false);
+                    throw new Exception("Should never be called on Installed");
+                }
+            }
+
+            public override string Reason
+            {
+                get { return "  Currently installed.\n"; }
+            }            
+        }
 
         public class UserRequested : Relationship
         {
@@ -416,7 +464,7 @@ namespace CKAN
 
             public override string Reason
             {
-                get { return "  Was installed or requested by user.\n"; }
+                get { return "  Requested by user.\n"; }
             }
         }
 

--- a/Relationships/RelationshipResolver.cs
+++ b/Relationships/RelationshipResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.CodeDom;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -71,14 +72,15 @@ namespace CKAN
         private static readonly ILog log = LogManager.GetLogger(typeof (RelationshipResolver));
         private readonly Dictionary<string, CkanModule> modlist = new Dictionary<string, CkanModule>();
         private readonly List<CkanModule> user_requested_mods = new List<CkanModule>();
-        private readonly List<KeyValuePair<Module, Module>> conflicts =
+        private readonly List<KeyValuePair<Module, Module>> conflicts = 
             new List<KeyValuePair<Module, Module>>();
-        private readonly Dictionary<Module, Relationship> reasons = new Dictionary<Module, Relationship>(new Module.IdentifierEqualilty());
+        private readonly Dictionary<Module, Relationship> reasons = 
+            new Dictionary<Module, Relationship>(new Module.IdentifierEqualilty());
 
         private readonly Registry registry;
         private readonly KSPVersion kspversion;
         private readonly RelationshipResolverOptions options;
-        private IEnumerable<Module> installed;
+        private readonly HashSet<Module> installed_modules;
 
 
         public RelationshipResolver(RelationshipResolverOptions options, Registry registry, KSPVersion kspversion)
@@ -86,6 +88,13 @@ namespace CKAN
             this.registry = registry;
             this.kspversion = kspversion;
             this.options = options;
+
+            installed_modules = new HashSet<Module>(registry.InstalledModules.Select(i_module => i_module.Module));
+            var installed_relationship = new Relationship.Installed();
+            foreach (var module in installed_modules)
+            {
+                reasons.Add(module, installed_relationship);
+            }
         }
 
         public RelationshipResolver(IEnumerable<string> module_names, RelationshipResolverOptions options, Registry registry,
@@ -132,18 +141,8 @@ namespace CKAN
         /// </summary>
         /// <param name="modules">Modules to checkattempt to install</param>
         /// <param name="installed_modules">Currently installed modules to consider</param>
-        public void AddModulesToInstall(IEnumerable<CkanModule> modules, IEnumerable<Module> installed_modules = null)
+        public void AddModulesToInstall(IEnumerable<CkanModule> modules)
         {                        
-            if (installed_modules == null)
-            {
-                installed = installed_modules = registry.InstalledModules.Select(i_module => i_module.Module).ToArray();
-            }
-
-            var installed_relationship = new Relationship.Installed();
-            foreach (var module in installed_modules)
-            {
-                reasons.Add(module, installed_relationship);
-            }
             //Count may need to do a full enumeration. Might as well convert to array
             var ckan_modules = modules as CkanModule[] ?? modules.ToArray();
             log.DebugFormat("Processing relationships for {0} modules", ckan_modules.Count());
@@ -196,6 +195,19 @@ namespace CKAN
                     final_modules,
                     registry.InstalledDlls
                     );
+            }
+        }
+
+        /// <summary>
+        /// Removes mods from the list of installed modules. Intended to be used for cases 
+        /// in which the mod is to be uninstalled.
+        /// </summary>
+        /// <param name="mods">The mods to remove.</param>
+        public void RemoveModsFromInstalledList(IEnumerable<Module> mods)
+        {
+            foreach (var module in mods)
+            {
+                installed_modules.Remove(module);
             }
         }
 
@@ -287,7 +299,7 @@ namespace CKAN
                 // list thus far, as well as everything on the system.
 
                 var fixed_mods = new HashSet<Module>(modlist.Values);
-                fixed_mods.UnionWith(installed);
+                fixed_mods.UnionWith(installed_modules);
 
                 var conflicting_mod = fixed_mods.FirstOrDefault(mod => mod.ConflictsWith(candidate));
                 if (conflicting_mod == null)

--- a/Relationships/RelationshipResolver.cs
+++ b/Relationships/RelationshipResolver.cs
@@ -388,7 +388,7 @@ namespace CKAN
 
         public bool IsConsistant
         {
-            get { return conflicts.Any(); }
+            get { return !conflicts.Any(); }
         }
 
         internal Relationship ReasonFor(CkanModule mod)

--- a/Tests/CKAN/Relationships/RelationshipResolver.cs
+++ b/Tests/CKAN/Relationships/RelationshipResolver.cs
@@ -771,7 +771,7 @@ namespace Tests.CKAN.Relationships
 
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
             var reason = relationship_resolver.ReasonFor(mod);
-            Assert.That(reason,Is.AssignableTo<Relationship.UserRequested>());
+            Assert.That(reason,Is.AssignableTo<SelectionReason.UserRequested>());
         }
 
         [Test]
@@ -786,7 +786,7 @@ namespace Tests.CKAN.Relationships
             options.with_all_suggests = true;
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
             var reason = relationship_resolver.ReasonFor(sugested);
-            Assert.That(reason, Is.AssignableTo<Relationship.Suggested>());
+            Assert.That(reason, Is.AssignableTo<SelectionReason.Suggested>());
             Assert.That(reason.Parent,Is.EqualTo(mod));
         }
 
@@ -810,11 +810,11 @@ namespace Tests.CKAN.Relationships
             options.with_recommends = true;
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
             var reason = relationship_resolver.ReasonFor(recommendedA);
-            Assert.That(reason, Is.AssignableTo<Relationship.Recommended>());
+            Assert.That(reason, Is.AssignableTo<SelectionReason.Recommended>());
             Assert.That(reason.Parent, Is.EqualTo(sugested));
 
             reason = relationship_resolver.ReasonFor(recommendedB);
-            Assert.That(reason, Is.AssignableTo<Relationship.Recommended>());
+            Assert.That(reason, Is.AssignableTo<SelectionReason.Recommended>());
             Assert.That(reason.Parent, Is.EqualTo(sugested));
         }
 

--- a/Tests/CKAN/Relationships/RelationshipResolver.cs
+++ b/Tests/CKAN/Relationships/RelationshipResolver.cs
@@ -65,6 +65,29 @@ namespace Tests.CKAN.Relationships
         }
 
         [Test]
+        public void RemoveModsFromInstalledList_RemovedModsDoNotConflict()
+        {
+            var list = new List<string>();
+            var mod_a = generator.GeneratorRandomModule();
+            var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
+            {
+                new RelationshipDescriptor {name=mod_a.identifier}
+            });
+
+            list.Add(mod_a.identifier);
+            list.Add(mod_b.identifier);
+            AddToRegistry(mod_a, mod_b);
+            registry.RegisterModule(mod_a,new string[]{},null);
+
+
+            var resolver = new RelationshipResolver(options, registry, null);
+            resolver.RemoveModsFromInstalledList(new[] {mod_a});
+            resolver.AddModulesToInstall(new[] { mod_b} );
+            Assert.IsTrue(resolver.IsConsistant);
+
+        }
+
+        [Test]
         [Category("Version")]
         [Explicit("Versions relationships not implemented")]
         public void Constructor_WithConflictingModulesVersion_Throws()

--- a/Types/Module.cs
+++ b/Types/Module.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization;
 using log4net;
 using Newtonsoft.Json;
 using System.Text.RegularExpressions;
+using System.Transactions;
 
 namespace CKAN
 {
@@ -35,7 +36,7 @@ namespace CKAN
     // Base class for both modules (installed via the CKAN) and bundled
     // modules (which are more lightweight)
     [JsonObject(MemberSerialization.OptIn)]
-    public class Module
+    public class Module : IEquatable<Module>
     {
         private static readonly ILog log = LogManager.GetLogger(typeof(Module));
 
@@ -274,6 +275,11 @@ namespace CKAN
             }
         }
 
+        bool IEquatable<Module>.Equals(Module other)
+        {
+            return Equals(other);
+        }
+
         public class IdentifierEqualilty : EqualityComparer<Module>
         {
             public override bool Equals(Module x, Module y)
@@ -448,7 +454,7 @@ namespace CKAN
 
         public override int GetHashCode()
         {
-            return identifier.GetHashCode() ^ version.GetHashCode();
+            return base.GetHashCode();
         }
 
 

--- a/Types/Module.cs
+++ b/Types/Module.cs
@@ -252,6 +252,39 @@ namespace CKAN
             }
         }
 
+        protected bool Equals(Module other)
+        {
+            return string.Equals(identifier, other.identifier) && version.Equals(other.version);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Module) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (identifier.GetHashCode()*397) ^ version.GetHashCode();
+            }
+        }
+
+        public class IdentifierEqualilty : EqualityComparer<Module>
+        {
+            public override bool Equals(Module x, Module y)
+            {
+                return x.identifier.Equals(y.identifier);
+            }
+
+            public override int GetHashCode(Module obj)
+            {
+                return obj.identifier.GetHashCode();
+            }
+        }
     }
 
     public class CkanModule : Module

--- a/Types/Module.cs
+++ b/Types/Module.cs
@@ -187,6 +187,7 @@ namespace CKAN
         /// </summary>
         public bool ConflictsWith(Module module)
         {
+            if(Equals(module)) return false;
             return UniConflicts(this, module) || UniConflicts(module, this);
         }
 


### PR DESCRIPTION
Should be a no-op (expect for the new relationship type) for clients that use existing ctors
