### PR TITLE
If only a single instance is present, use that

### DIFF
--- a/KSPManager.cs
+++ b/KSPManager.cs
@@ -87,6 +87,11 @@ namespace CKAN
                 return new KSP(path, User);
             }
 
+            // If we only know of a single instance, return that.
+            if (instances.Count == 1)
+            {
+                return instances.First().Value;
+            }
 
             // Return the autostart, if we can find it.
             if (AutoStartInstance != null)
@@ -101,13 +106,6 @@ namespace CKAN
                 {
                     return instances[AutoStartInstance];
                 }
-            }
-
-           
-            // If we only know of a single instance, return that.
-            if (instances.Count == 1)
-            {
-                return instances.First().Value;
             }
 
             // If we know of no instances, try to find one.

--- a/Tests/CKAN/KSPManager.cs
+++ b/Tests/CKAN/KSPManager.cs
@@ -174,7 +174,6 @@ namespace CKANTests
             
         }
 
-
         public FakeWin32Registry(List<Tuple<string, string>> instances, string auto_start_instance = null)
         {
             Instances = instances;
@@ -188,7 +187,26 @@ namespace CKANTests
             get { return Instances.Count; }
             }
 
-        public string AutoStartInstance { get; set; }
+        // In the Win32Registry it is not possible to get null in autostart.
+        private string _AutoStartInstance;
+        public string AutoStartInstance
+        {
+            get
+            {
+                if (_AutoStartInstance != null)
+                {
+                    return _AutoStartInstance;
+                }
+                else
+                {
+                    return string.Empty;
+                }
+            }
+            set
+            {
+                _AutoStartInstance = value;
+            }
+        }
 
         public Tuple<string, string> GetInstance(int i)
         {

--- a/Tests/CKAN/KSPManager.cs
+++ b/Tests/CKAN/KSPManager.cs
@@ -51,10 +51,10 @@ namespace CKANTests
         }
 
         [Test]
-        public void SetAutoStart_InvaildName_DoesNotChangeAutoStart()
+        public void SetAutoStart_InvalidName_DoesNotChangeAutoStart()
         {
             manager.SetAutoStart(nameInReg);
-            Assert.Throws<InvalidKSPInstanceKraken>(() => manager.SetAutoStart("invaild"));
+            Assert.Throws<InvalidKSPInstanceKraken>(() => manager.SetAutoStart("invalid"));
             Assert.That(manager.AutoStartInstance, Is.EqualTo(nameInReg));
         }
 
@@ -136,13 +136,13 @@ namespace CKANTests
         [Test]
         public void SetCurrentInstance_NameNotInRepo_Throws()
         {
-            Assert.Throws<InvalidKSPInstanceKraken>(() => manager.SetCurrentInstance("invaild"));
+            Assert.Throws<InvalidKSPInstanceKraken>(() => manager.SetCurrentInstance("invalid"));
         }
 
         [Test] //37a33
-        public void Ctor_InvaildAutoStart_DoesNotThrow()
+        public void Ctor_InvalidAutoStart_DoesNotThrow()
         {
-            Assert.DoesNotThrow(() => new KSPManager(new NullUser(),new FakeWin32Registry(tidy.KSP,"invaild")
+            Assert.DoesNotThrow(() => new KSPManager(new NullUser(),new FakeWin32Registry(tidy.KSP, "invalid")
                 ));
         }
 

--- a/Tests/CKAN/KSPManager.cs
+++ b/Tests/CKAN/KSPManager.cs
@@ -44,7 +44,7 @@ namespace CKANTests
         [Test]
         public void SetAutoStart_VaildName_SetsAutoStart()
         {         
-            Assert.That(manager.AutoStartInstance, Is.EqualTo(null));
+            Assert.That(manager.AutoStartInstance, Is.EqualTo(string.Empty));
 
             manager.SetAutoStart(nameInReg);
             Assert.That(manager.AutoStartInstance, Is.EqualTo(nameInReg));


### PR DESCRIPTION
A few times users have reported, when we attempt to help them using the CLI, that CKAN request the selection of an instance even though there is only one available.

Looking at the code, the intended behavior if only one KSP instance is present is to use that instance. Due to a way the test implementation of Win32Registry was implemented, it could return a value for AutoStartInstance (null) that the real implementation was unable to (Would default to an empty string). Thus, the tests shows everything is working as intended, when it isn't on real systems.

Rearranging the order of the code in KSPManager seems to fix this issue, both in test and on real systems.

An unresolved with this is that we now test is the autostart instance is null, when it never can be null, however I don't want to get too invasive in the code changes.