### PR TITLE
Fix detecting when CKAN is running on Mac OS X

### DIFF
--- a/Platform.cs
+++ b/Platform.cs
@@ -19,10 +19,10 @@ namespace CKAN
             IsMac = IsRunningOnMac();
         }
 
-        // From https://github.com/mono/monodevelop/blob/7c51ae11c323d429c10acd22169373927217198f/main/src/core/Mono.Texteditor/Mono.TextEditor/Platform.cs
-        // TODO: how to obey license for that?
+        // From https://github.com/mono/monodevelop/blob/master/main/src/core/Mono.Texteditor/Mono.TextEditor/Platform.cs
         // Environment.OSVersion.Platform returns Unix for Mac OS X as of Mono v4.0.0:
         // https://bugzilla.xamarin.com/show_bug.cgi?id=13345
+        // So we have to detect it another way
         static bool IsRunningOnMac ()
         {
             IntPtr buf = IntPtr.Zero;

--- a/Platform.cs
+++ b/Platform.cs
@@ -7,10 +7,45 @@
 /// This uses the modern technique of checking PlatformID enums, rather than
 /// magic numbers like we used to.
 /// </summary>
+using System.Runtime.InteropServices;
+
+
 namespace CKAN
 {
     public static class Platform
     {
+       static Platform ()
+        {
+            IsMac = IsRunningOnMac();
+        }
+
+        // From https://github.com/mono/monodevelop/blob/7c51ae11c323d429c10acd22169373927217198f/main/src/core/Mono.Texteditor/Mono.TextEditor/Platform.cs
+        // TODO: how to obey license for that?
+        // Environment.OSVersion.Platform returns Unix for Mac OS X as of Mono v4.0.0:
+        // https://bugzilla.xamarin.com/show_bug.cgi?id=13345
+        static bool IsRunningOnMac ()
+        {
+            IntPtr buf = IntPtr.Zero;
+            try {
+                buf = Marshal.AllocHGlobal (8192);
+                // This is a hacktastic way of getting sysname from uname ()
+                if (uname (buf) == 0) {
+                    string os = Marshal.PtrToStringAnsi (buf);
+                    if (os == "Darwin")
+                        return true;
+                }
+            } catch {
+            } finally {
+                if (buf != IntPtr.Zero)
+                    Marshal.FreeHGlobal (buf);
+            }
+            return false;
+        }
+
+        [DllImport ("libc")]
+        static extern int uname (IntPtr buf);
+
+
         /// <summary>
         /// Are we on a Unix (including Linux, but *not* Mac) system.
         /// </summary>
@@ -28,12 +63,8 @@ namespace CKAN
         /// </summary>
         /// <value><c>true</c> if is mac; otherwise, <c>false</c>.</value>
         public static bool IsMac
-        {
-            get
-            {
-                return Environment.OSVersion.Platform == PlatformID.MacOSX;
-            }
-        }
+        { get; private set; }
+            
 
         /// <summary>
         /// Are we on a flavour of Windows? This is implemented internally by checking


### PR DESCRIPTION
Environment.OSVersion.Platform never returns PlatformID.MacOSX. Instead, on Macs it returns PlatformID.Unix, so we have to detect Macs another way.

I pulled the code that Monodevelop uses for this since it seemed like the most robust way and I'm not familiar with making native calls in Mono. Not sure if we need to add their copyright to the code for this snippet or if doesn't count as a "substantial portion"?