### PR TITLE
Change autostart instance to have a public getter.

### DIFF
--- a/KSPManager.cs
+++ b/KSPManager.cs
@@ -21,7 +21,7 @@ namespace CKAN
 
         private readonly SortedList<string, KSP> instances = new SortedList<string, KSP>();
 
-        internal string AutoStartInstance
+        public string AutoStartInstance
         {
             get { return Win32Registry.AutoStartInstance; }
             private set


### PR DESCRIPTION
Needed to fix https://github.com/KSP-CKAN/CKAN/issues/860 without a full rewrite of the GUI.