### PR TITLE
Use all repositories in update instead of just the hardcoded default.

### DIFF
--- a/Net/Repo.cs
+++ b/Net/Repo.cs
@@ -95,16 +95,24 @@ namespace CKAN
 
         public static int Update(RegistryManager registry_manager, KSP ksp, IUser user, Boolean clear = true, Uri repo = null)
         {
-            // Use our default repo, unless we've been told otherwise.
+            // Use all repositories, unless we've been told otherwise.
             if (repo == null)
             {
-                repo = default_ckan_repo;
+                foreach(var r in ksp.Registry.Repositories)
+                {
+                    UpdateRegistry(r.Value.uri, registry_manager.registry, ksp, user, clear);
+
+                    // Save our changes.
+                    registry_manager.Save();
+                }
             }
+            else
+            {
+                UpdateRegistry(repo, registry_manager.registry, ksp, user, clear);
 
-            UpdateRegistry(repo, registry_manager.registry, ksp, user, clear);
-
-            // Save our changes!
-            registry_manager.Save();
+                // Save our changes.
+                registry_manager.Save();
+            }
 
             // Return how many we got!
             return registry_manager.registry.Available(ksp.Version()).Count;


### PR DESCRIPTION
In the CLI, replacing the default repository with a custom one makes the update command behavior wrong. It will pull in the hardcoded default repository instead of the one listed in the registry. The comment in the CLI suggests that calling the Update command with repo == null should result in all repositories getting updated. This change should fix that.