### PR TITLE
Cache downloads globally

### DIFF
--- a/Net/NetFileCache.cs
+++ b/Net/NetFileCache.cs
@@ -203,6 +203,36 @@ namespace CKAN
                 Directory.CreateDirectory(new_cache_path);
             }
 
+            // Check that we have list permission.
+            try
+            {
+                Directory.GetFiles(new_cache_path);
+            }
+            catch(System.UnauthorizedAccessException e)
+            {
+                return false;
+            }
+                
+            string test_file_path = Path.Combine(new_cache_path, "testing_file_for_CKAN");
+
+            // Check that we have read/write permission.
+            try
+            {
+                FileStream a = File.Create(test_file_path);
+                a.WriteByte(0);
+                a.Close();
+
+                a = File.OpenRead(test_file_path);
+                a.ReadByte();
+                a.Close();
+
+                File.Delete(test_file_path);
+            }
+            catch(System.UnauthorizedAccessException e)
+            {
+                return false;
+            }
+
             // TODO: Start a new transaction.
 
             // Get a list of all the files in the old cache and move them over.
@@ -212,7 +242,7 @@ namespace CKAN
             {
                 string new_file_path = Path.Combine(new_cache_path, Path.GetFileName(file));
 
-                tx_file.Copy(file, new_file_path);
+                tx_file.Copy(file, new_file_path, true);
             }
 
             // Store the new location in the registry and internally.
@@ -225,6 +255,8 @@ namespace CKAN
             {
                 tx_file.Delete(file);
             }
+
+            return true;
         }
 
         /// <summary>

--- a/Net/NetFileCache.cs
+++ b/Net/NetFileCache.cs
@@ -189,6 +189,44 @@ namespace CKAN
             return null;
         }
 
+        public bool MoveDefaultCache(string new_cache_path)
+        {
+            // Check input.
+            if (string.IsNullOrWhiteSpace(new_cache_path))
+            {
+                return false;
+            }
+
+            // Create the new path if it doesn't exists.
+            if (!Directory.Exists(new_cache_path))
+            {
+                Directory.CreateDirectory(new_cache_path);
+            }
+
+            // TODO: Start a new transaction.
+
+            // Get a list of all the files in the old cache and move them over.
+            var files = Directory.GetFiles(cache_path);
+
+            foreach (string file in files)
+            {
+                string new_file_path = Path.Combine(new_cache_path, Path.GetFileName(file));
+
+                tx_file.Copy(file, new_file_path);
+            }
+
+            // Store the new location in the registry and internally.
+            Win32Registry registry = new Win32Registry();
+            registry.SetCachePath(new_cache_path);
+            cache_path = new_cache_path;
+
+            // Clean the old directory of files we moved.
+            foreach (string file in files)
+            {
+                tx_file.Delete(file);
+            }
+        }
+
         /// <summary>
         /// Stores the results of a given URL in the cache.
         /// Description is appended to the file hash when saving. If not present, the filename will be used.

--- a/Win32Registry.cs
+++ b/Win32Registry.cs
@@ -6,7 +6,6 @@ namespace CKAN
 {
     public interface IWin32Registry
     {
-
         string AutoStartInstance { get; set; }
         void SetRegistryToInstances(SortedList<string, KSP> instances, string auto_start_instance);
         IEnumerable<Tuple<string, string>> GetInstances();
@@ -20,6 +19,7 @@ namespace CKAN
         {
             ConstructKey();
         }
+
         private int InstanceCount
         {
             get { return GetRegistryValue(@"KSPInstanceCount", 0); }
@@ -47,13 +47,37 @@ namespace CKAN
             {                
                 SetInstanceKeysTo(instance.number, instance.name, instance.path);                
             }
-
-            
         }
 
         public IEnumerable<Tuple<string, string>> GetInstances()
         {
             return Enumerable.Range(0, InstanceCount).Select(GetInstance).ToList();
+        }
+
+        /// <summary>
+        /// Gets the global downloads cache path.
+        /// </summary>
+        /// <returns>The cache path.</returns>
+        public string GetCachePath()
+        {
+            return GetRegistryValue(@"GlobalCache", String.Empty);
+        }
+
+        /// <summary>
+        /// Store the global cache path in the registry.
+        /// 
+        /// Allows setting the path to an empty string to disable the global cache.
+        /// </summary>
+        /// <param name="cache_path">Cache path.</param>
+        public void SetCachePath(string cache_path)
+        {
+            // Do not write null to the registry.
+            if (cache_path == null)
+            {
+                cache_path = string.Empty;
+            }
+
+            SetRegistryValue(@"GlobalCache", cache_path);
         }
 
         private void ConstructKey()


### PR DESCRIPTION
This is the beginning of a global cache for downloads. There is a test for r/w access, and an option for moving a cache. Currently, there is no way to go from the local cache in the client into the global cache.

Still a work in progress.
