### PR TITLE
Make sure cache hints are filesystem safe.

### DIFF
--- a/Net/NetFileCache.cs
+++ b/Net/NetFileCache.cs
@@ -5,6 +5,7 @@ using System.Text;
 using ChinhDo.Transactions;
 using ICSharpCode.SharpZipLib.Zip;
 using log4net;
+using System.Text.RegularExpressions;
 
 namespace CKAN
 {
@@ -129,7 +130,8 @@ namespace CKAN
 
         /// <summary>
         /// Stores the results of a given URL in the cache.
-        /// Description is appended to the file hash when saving. If not present, the filename will be used.
+        /// Description is adjusted to be filesystem-safe and then appended to the file hash when saving.
+        /// If not present, the filename will be used.
         /// If `move` is true, then the file will be moved; otherwise, it will be copied.
         /// 
         /// Returns a path to the newly cached file.
@@ -144,6 +146,16 @@ namespace CKAN
             Remove(url);
 
             string hash = CreateURLHash(url);
+
+            if (description != null)
+            {
+                // Versions can contain ALL SORTS OF WACKY THINGS! Colons, friggin newlines,
+                // slashes, and heaven knows what use mod authors try to smoosh into them.
+                // We'll reduce this down to "friendly" characters, replacing everything else with
+                // dashes. This doesn't change look-ups, as we use the hash prefix for that.
+
+                description = Regex.Replace(description, "[^A-Za-z0-9_.-]", "-");
+            }
 
             description = description ?? Path.GetFileName(path);
 

--- a/Tests/CKAN/Cache.cs
+++ b/Tests/CKAN/Cache.cs
@@ -54,16 +54,17 @@ namespace CKANTests
             FileAssert.AreEqual(file, cached_file);
         }
 
-        [Test]
-        public void NamingHints()
+        [Test, TestCase("cheesy.zip","cheesy.zip"), TestCase("Foo-1:2.3","Foo-1-2.3"),
+            TestCase("Foo-1:2:3","Foo-1-2-3"), TestCase("Foo/../etc/passwd","Foo-..-etc-passwd")]
+        public void NamingHints(string hint, string appendage)
         {
             Uri url = new Uri("http://example.com/");
             string file = Tests.TestData.DogeCoinFlagZip();
 
             Assert.IsFalse(cache.IsCached(url));
-            cache.Store(url, file, "cheesy.zip");
+            cache.Store(url, file, hint);
 
-            StringAssert.EndsWith("cheesy.zip", cache.GetCachedFilename(url));
+            StringAssert.EndsWith(appendage, cache.GetCachedFilename(url));
         }
 
         [Test]

--- a/Types/Version.cs
+++ b/Types/Version.cs
@@ -51,6 +51,11 @@ namespace CKAN {
             this.version = match.Groups["version"].Value;
         }
 
+        /// <summary>
+        /// Returns the original string used to generate this version. Note this may *NOT* be
+        /// safe for use in filenames, as it may contain colons (for the epoch) and other
+        /// funny characters.
+        /// </summary>
         override public string ToString() {
             return orig_string;
         }


### PR DESCRIPTION
This picks up weird things like ':' from epochs, but also potentially
more dangerous hints if people have versions like "../../../etc/passwd"
for their mods.

Relates somewhat to KSP-CKAN/CKAN-netkan#60