### PR TITLE
Fix Steam detection on Linux

### DIFF
--- a/KSP.cs
+++ b/KSP.cs
@@ -131,25 +131,20 @@ namespace CKAN
         /// </summary>
         public static string FindGameDir()
         {
-
             // See if we can find KSP as part of a Steam install.
+            string ksp_steam_path = KSPPathUtils.KSPSteamPath();
 
-            string steam = KSPPathUtils.SteamPath();
-            if (steam != null)
+            if (ksp_steam_path != null)
             {
-                string ksp_dir = Path.Combine(steam, KSPManager.steamKSP);
-
-                if (Directory.Exists(ksp_dir) && IsKspDir(ksp_dir))
+                if (IsKspDir(ksp_steam_path))
                 {
-                    log.InfoFormat("KSP found at {0}", ksp_dir);
-                    return ksp_dir;
+                    return ksp_steam_path;
                 }
 
-                log.DebugFormat("Have Steam, but KSP is not at {0}", ksp_dir);
+                log.DebugFormat("Have Steam, but KSP is not at \"{0}\".", ksp_steam_path);
             }
 
             // Oh noes! We can't find KSP!
-
             throw new DirectoryNotFoundException();
         }
 

--- a/KSPManager.cs
+++ b/KSPManager.cs
@@ -100,7 +100,8 @@ namespace CKAN
                 // This is neccessary so we can indicate that the user wants to reset the current AutoStartInstance without clearing the windows registry keys!
                 if (AutoStartInstance == "")
                 {
-                    return null;
+                    //return null;
+                    //break;
                 }
                 if (HasInstance(AutoStartInstance))
                 {
@@ -303,11 +304,6 @@ namespace CKAN
                 AutoStartInstance = null;
             }
         }
-
-        public static readonly string steamKSP = Path.Combine("steamapps", "common", "Kerbal Space Program");
-        }
-
-
     }
 
     public class KSPManagerKraken : Kraken
@@ -327,3 +323,4 @@ namespace CKAN
             this.instance = instance;
         }
     }
+}

--- a/KSPManager.cs
+++ b/KSPManager.cs
@@ -100,8 +100,7 @@ namespace CKAN
                 // This is neccessary so we can indicate that the user wants to reset the current AutoStartInstance without clearing the windows registry keys!
                 if (AutoStartInstance == "")
                 {
-                    //return null;
-                    //break;
+                    return null;
                 }
                 if (HasInstance(AutoStartInstance))
                 {

--- a/KSPManager.cs
+++ b/KSPManager.cs
@@ -304,7 +304,7 @@ namespace CKAN
             }
         }
 
-        public static readonly string steamKSP = Path.Combine("SteamApps", "common", "Kerbal Space Program");
+        public static readonly string steamKSP = Path.Combine("steamapps", "common", "Kerbal Space Program");
         }
 
 

--- a/KSPPathUtils.cs
+++ b/KSPPathUtils.cs
@@ -10,9 +10,9 @@ namespace CKAN
         private static readonly ILog log = LogManager.GetLogger(typeof(KSPPathUtils));
 
         /// <summary>
-        ///     Finds Steam on the current machine.
+        /// Finds Steam on the current machine.
         /// </summary>
-        /// <returns>The path to steam, or null if not found</returns>
+        /// <returns>The path to Steam, or null if not found</returns>
         public static string SteamPath()
         {
             // First check the registry.
@@ -24,7 +24,7 @@ namespace CKAN
 
             var steam = (string)Microsoft.Win32.Registry.GetValue(reg_key, reg_value, null);
 
-            // If that directory exists, we've found steam!
+            // If that directory exists, we've found Steam!
             if (steam != null && Directory.Exists(steam))
             {
                 log.InfoFormat("Found Steam at {0}", steam);
@@ -34,11 +34,27 @@ namespace CKAN
             log.Debug("Couldn't find Steam via registry key, trying other locations...");
 
             // Not in the registry, or missing file, but that's cool. This should find it on Linux
-
             steam = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.Personal),
-                ".steam", "steam"
-                );
+                ".local",
+                "share",
+                "Steam"
+            );
+
+            log.DebugFormat("Looking for Steam in {0}", steam);
+
+            if (Directory.Exists(steam))
+            {
+                log.InfoFormat("Found Steam at {0}", steam);
+                return steam;
+            }
+
+            // Try an alternative path.
+            steam = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+                ".steam",
+                "steam"
+            );
 
             log.DebugFormat("Looking for Steam in {0}", steam);
 
@@ -64,6 +80,41 @@ namespace CKAN
             }
 
             log.Info("Steam not found on this system.");
+            return null;
+        }
+
+        /// <summary>
+        /// Finds the KSP path under Steam. Returns null if the folder cannot be located.
+        /// </summary>
+        /// <returns>The KSP path.</returns>
+        public static string KSPSteamPath()
+        {
+            // Attempt to get the Steam path.
+            string steam_path = SteamPath();
+
+            if (steam_path == null)
+            {
+                return null;
+            }
+
+            // There are several possibilities for the path under Linux.
+            // Try with the uppercase version.
+            string ksp_path = Path.Combine(steam_path, "SteamApps", "common", "Kerbal Space Program");
+
+            if (Directory.Exists(ksp_path))
+            {
+                return ksp_path;
+            }
+
+            // Try with the lowercase version.
+            ksp_path = Path.Combine(steam_path, "steamapps", "common", "Kerbal Space Program");
+
+            if (Directory.Exists(ksp_path))
+            {
+                return ksp_path;
+            }
+
+            // Could not locate the folder.
             return null;
         }
 


### PR DESCRIPTION
We have had a few cases where Steam install went undetected. My local install and that of zeropositivo on IRC is of the lowercase version. The one which @pjf have uses the capitalized variant. Also, Steam can be found in both **.steam/steam** and **.local/share/Steam**.

This should test for all of these cases. Would like tests on a few different Linux systems prior to merge. It detects my install on Arch.

Closes https://github.com/KSP-CKAN/CKAN/issues/941.