### PR TITLE
Revert "Tweaked ResolveStanza() to always pick a candidate"

### DIFF
--- a/Relationships/RelationshipResolver.cs
+++ b/Relationships/RelationshipResolver.cs
@@ -244,10 +244,16 @@ namespace CKAN
                     log.InfoFormat("{0} is recommended/suggested, but nothing provides it.", dep_name);
                     continue;
                 }
-                // Only throw TooManyModsProvideKraken if too many candidates and 
-                // if we actually care that there are too many candidates
-                if (candidates.Count > 1 && !options.without_toomanyprovides_kraken)
+                if (candidates.Count > 1)
                 {
+                    // Oh no, too many to pick from!
+                    // TODO: It would be great if instead we picked the one with the
+                    // most recommendations.
+                    if (options.without_toomanyprovides_kraken)
+                    {
+                        continue;
+                    }
+
                     throw new TooManyModsProvideKraken(dep_name, candidates);
                 }
 


### PR DESCRIPTION
Unfortunately, this doesn't restore the behaviour where the GUI actually
gives you choices of things to install. We'll need a separate ticket to
track that. However this is still better than crashing the client.

This reverts commit 72577c59d88e29ec1f326cbed58b35921fbb5676.

Fixes KSP-CKAN/CKAN-GUI#95.
Fixes KSP-CKAN/CKAN#975
Fixes KSP-CKAN/CKAN#864
May provide relief to KSP-CKAN/CKAN#907